### PR TITLE
add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE
+include requirements.txt


### PR DESCRIPTION
otherwise requirements.txt would be missing in Pypi's SDIST archive:

```
>>> Emerging (1 of 1) dev-python/tuya-iot-py-sdk-0.4.1::HomeAssistantRepository
>>> Failed to emerge dev-python/tuya-iot-py-sdk-0.4.1, Log file:
>>>  '/var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/temp/build.log'
>>> Jobs: 0 of 1 complete, 1 failed                 Load avg: 0.23, 0.13, 0.13
 * Package:    dev-python/tuya-iot-py-sdk-0.4.1
 * Repository: HomeAssistantRepository
 * Maintainer: b@edevau.net
 * Upstream:   developer@tuya.com
 * USE:        abi_x86_64 amd64 elibc_glibc kernel_linux python_targets_python3_9 test userland_GNU
 * FEATURES:   network-sandbox preserve-libs sandbox userpriv usersandbox
>>> Unpacking source...
>>> Unpacking tuya-iot-py-sdk-0.4.1.tar.gz to /var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work
>>> Source unpacked in /var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work
>>> Preparing source in /var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1 ...
>>> Source prepared.
>>> Configuring source in /var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1 ...
>>> Source configured.
>>> Compiling source in /var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1 ...
 * python3_9: running distutils-r1_run_phase distutils-r1_python_compile
python3.9 setup.py build -j 6
/var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1/tuya_iot/home.py:67: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if (asset_id is not "-1"):
Traceback (most recent call last):
  File "/var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1/setup.py", line 49, in <module>
    install_requires=requirements(),
  File "/var/tmp/portage/dev-python/tuya-iot-py-sdk-0.4.1/work/tuya-iot-py-sdk-0.4.1/setup.py", line 12, in requirements
    with open('requirements.txt', 'r') as fileobj:
FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
 * ERROR: dev-python/tuya-iot-py-sdk-0.4.1::HomeAssistantRepository failed (compile phase):
 *   (no error message)
 *
 * Call stack:
 *     ebuild.sh, line  127:  Called src_compile
 *   environment, line 2856:  Called distutils-r1_src_compile
 *   environment, line 1161:  Called _distutils-r1_run_foreach_impl 'distutils-r1_python_compile'
 *   environment, line  455:  Called python_foreach_impl 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2534:  Called multibuild_foreach_variant '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2064:  Called _multibuild_run '_python_multibuild_wrapper' 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line 2062:  Called _python_multibuild_wrapper 'distutils-r1_run_phase' 'distutils-r1_python_compile'
 *   environment, line  766:  Called distutils-r1_run_phase 'distutils-r1_python_compile'
 *   environment, line 1152:  Called distutils-r1_python_compile
 *   environment, line 1010:  Called esetup.py 'build' '-j' '6'
 *   environment, line 1599:  Called die
 * The specific snippet of code:
 *       "${@}" || die -n;
 *
```