### PR TITLE
Add pyenv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,9 +83,7 @@ profile_default/
 ipython_config.py
 
 # pyenv
-#   For a library or package, you might want to ignore these files since the code is
-#   intended to run in multiple environments; otherwise, check them in:
-# .python-version
+.python-version
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.


### PR DESCRIPTION
A small PR to add the `.python-version` file to the `.gitignore` file.

This allows developers (like me) to use `pyenv` more easily when developing this library, while using different environments and Python versions.
