### PR TITLE
Remove shebang and encoding markers from Python files

### DIFF
--- a/example/api.py
+++ b/example/api.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 import logging
 from tuya_iot import TuyaOpenAPI, tuya_logger
 

--- a/example/device.py
+++ b/example/device.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
-
 import logging
 from env import ENDPOINT, ACCESS_ID, ACCESS_KEY, USERNAME, PASSWORD
 from tuya_iot import (

--- a/example/env.py
+++ b/example/env.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
-
 # online
 # ACCESS_ID = # your_access_id
 # ACCESS_KEY = # your_access_key

--- a/example/mq.py
+++ b/example/mq.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
 import logging
 from tuya_iot import TuyaOpenAPI, TuyaOpenMQ, tuya_logger
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
-# from distutils.core import setup
 from setuptools import setup, find_packages
 from tuya_iot import __version__
 

--- a/tuya_iot/__init__.py
+++ b/tuya_iot/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 from .openapi import TuyaOpenAPI, TuyaTokenInfo
 from .openmq import TuyaOpenMQ
 from .asset import TuyaAssetManager

--- a/tuya_iot/asset.py
+++ b/tuya_iot/asset.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tuya asset api."""
 
 from typing import Any, Dict, List

--- a/tuya_iot/device.py
+++ b/tuya_iot/device.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
 """Tuya device api."""
 
 import abc

--- a/tuya_iot/home.py
+++ b/tuya_iot/home.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """Tuya home's api base on asset and device api."""
 
 from typing import Any, Dict

--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """Tuya Open API."""
 
 from __future__ import annotations

--- a/tuya_iot/openlogging.py
+++ b/tuya_iot/openlogging.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """Tuya iot logging."""
 
 import logging

--- a/tuya_iot/openmq.py
+++ b/tuya_iot/openmq.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: UTF-8 -*-
 """Tuya Open IOT HUB which base on MQTT."""
 
 import base64

--- a/tuya_iot/tuya_enums.py
+++ b/tuya_iot/tuya_enums.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """Tuya iot enums."""
 
 from enum import Enum

--- a/tuya_iot/version.py
+++ b/tuya_iot/version.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
 """tuya_iot version."""
 
 VERSION = "0.5.0"


### PR DESCRIPTION
This PR cleans up two things from all Python files.

1. **Removes shebang from every Python file**

	None of the Python files in this repository is actually marked as executable (which is good, as most of them should not be executable), this also means the shebang isn't needed. Therefore I've removed them and cleaned them up.

2. **Removes code encoding hint from every Python file**

	As of PEP 3120, the default encoding for Python source is UTF-8; Therefore, I've removed them and cleaned them all up. See: <https://www.python.org/dev/peps/pep-3120/>

