### PR TITLE
Mark Python 3.10, fix min Python version, setup cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,13 @@
 from setuptools import setup, find_packages
 from tuya_iot import __version__
 
-tests_require = []
-
 
 def requirements():
-    with open('requirements.txt', 'r') as fileobj:
-        requirements = [line.strip() for line in fileobj]
-        return requirements
+    with open('requirements.txt') as fileobj:
+        return [line.strip() for line in fileobj]
 
 
-with open("README.md", "r", encoding="utf-8") as fh:
+with open("README.md", encoding="utf-8") as fh:
     doc_long_description = fh.read()
 
 
@@ -42,16 +39,14 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
 
     version=__version__,
     install_requires=requirements(),
-    tests_require=tests_require,
     test_suite='runtests.runtests',
-    extras_require={'test': tests_require},
     entry_points={'nose.plugins': []},
     packages=find_packages(),
-    python_requires='>=3.0',
-
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
This PR adjusts a couple of things to the package setup.

- Mark/add Python 3.10
- Fixes `python_requires` to have 3.6+, as that is what this library needs
- Remove unneeded `'r'` reading mode on open (is the default)
- Removed unused `tests_require`