### PR TITLE
Fix type signature for send_commands methods

### DIFF
--- a/tuya_iot/device.py
+++ b/tuya_iot/device.py
@@ -481,7 +481,7 @@ class TuyaDeviceManager:
 
     def send_commands(self,
                       device_id: str,
-                      commands: List[str]) -> Dict[str, Any]:
+                      commands: List[Dict[str, Any]]) -> Dict[str, Any]:
         """Send commands.
 
         Send command to the device.For example:
@@ -617,7 +617,7 @@ class SmartHomeDeviceManage(DeviceManage):
     def get_device_specification(self, device_id: str) -> Dict[str, str]:
         return self.api.get("/v1.0/devices/{}/specifications".format(device_id))
 
-    def send_commands(self, device_id: str, commands: List[str]) -> Dict[str, Any]:
+    def send_commands(self, device_id: str, commands: List[Dict[str, Any]]) -> Dict[str, Any]:
         return self.api.post(
             "/v1.0/devices/{}/commands".format(
                 device_id), {"commands": commands}
@@ -666,7 +666,7 @@ class IndustrySolutionDeviceManage(DeviceManage):
     def get_device_specification(self, device_id: str) -> Dict[str, str]:
         return self.api.get("/v1.0/iot-03/devices/{}/specification".format(device_id))
 
-    def send_commands(self, device_id: str, commands: List[str]) -> Dict[str, Any]:
+    def send_commands(self, device_id: str, commands: List[Dict[str, Any]]) -> Dict[str, Any]:
         return self.api.post(
             "/v1.0/iot-03/devices/{}/commands".format(
                 device_id), {"commands": commands}


### PR DESCRIPTION
This PR fixes the `send_commands` methods, which were incorrectly typed.

![image](https://user-images.githubusercontent.com/195327/136915942-48bca7c2-064b-44fa-94c9-cc0c5b7d03d3.png)
