### PR TITLE
Fix type signature of TuyaDevice.status_range

### DIFF
--- a/tuya_iot/device.py
+++ b/tuya_iot/device.py
@@ -103,7 +103,7 @@ class TuyaDevice(SimpleNamespace):
 
     status: Dict[str, Any] = {}
     function: Dict[str, TuyaDeviceFunction] = {}
-    status_range: Dict[str, str] = {}
+    status_range: Dict[str, TuyaDeviceStatusRange] = {}
 
     def __eq__(self, other):
         """If devices are the same one."""


### PR DESCRIPTION
Fixes the typing of `TuyaDevice.status_range`, it is typed as `Dict[str, str]`, but this is incorrect and can never happen.

Instead it should be typed as `Dict[str, TuyaDeviceStatusRange]`