### PR TITLE
Fix non-existing reference to ABCMeta

### DIFF
--- a/tuya_iot/device.py
+++ b/tuya_iot/device.py
@@ -498,7 +498,7 @@ class TuyaDeviceManager:
     ##############################
 
 
-class DeviceManage(metaclass=abc.ABCMeta):
+class DeviceManage(metaclass=ABCMeta):
     api: TuyaOpenAPI
 
     def __init__(self, api: TuyaOpenAPI):


### PR DESCRIPTION
`abc.ABCMeta` no longer exists in this file, instead `ABCMeta` was imported directly.
This PR corrects this fact.

