### PR TITLE
Fix Python >=3.7,<3.9 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
@@ -44,5 +43,5 @@ setup(
     test_suite="runtests.runtests",
     entry_points={"nose.plugins": []},
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
 )

--- a/tuya_iot/asset.py
+++ b/tuya_iot/asset.py
@@ -1,4 +1,5 @@
 """Tuya asset api."""
+from __future__ import annotations
 
 from typing import Any
 

--- a/tuya_iot/device.py
+++ b/tuya_iot/device.py
@@ -1,4 +1,5 @@
 """Tuya device api."""
+from __future__ import annotations
 
 import time
 from abc import ABCMeta, abstractclassmethod
@@ -641,6 +642,8 @@ class SmartHomeDeviceManage(DeviceManage):
         if response["success"]:
             return response["result"]["url"]
         return None
+
+    def get_device_statistics_
 
     def send_commands(
         self, device_id: str, commands: list[dict[str, Any]]

--- a/tuya_iot/home.py
+++ b/tuya_iot/home.py
@@ -1,4 +1,5 @@
 """Tuya home's api base on asset and device api."""
+from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any

--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -1,5 +1,4 @@
 """Tuya Open API."""
-
 from __future__ import annotations
 
 import hashlib
@@ -248,7 +247,9 @@ class TuyaOpenAPI:
             headers["dev_channel"] = self.dev_channel
 
         if self.token_info is not None:
-            refresh_token_api = TO_C_REFRESH_TOKEN_API.format(self.token_info.refresh_token)
+            refresh_token_api = TO_C_REFRESH_TOKEN_API.format(
+                self.token_info.refresh_token
+            )
             if refresh_token_api == path:
                 headers["dev_lang"] = "python"
                 headers["dev_version"] = VERSION

--- a/tuya_iot/openlogging.py
+++ b/tuya_iot/openlogging.py
@@ -1,4 +1,5 @@
 """Tuya iot logging."""
+from __future__ import annotations
 
 import copy
 import logging

--- a/tuya_iot/openmq.py
+++ b/tuya_iot/openmq.py
@@ -1,4 +1,5 @@
 """Tuya Open IOT HUB which base on MQTT."""
+from __future__ import annotations
 
 import base64
 import json


### PR DESCRIPTION
This PR fixes compatibility with older Python versions.
PR #10 made use of a Python 3.9+ feature, causing this library no longer to work on older Python version.

This PR corrects that, with the side-effect that it will cause Python 3.7 to become the minimum (which IMHO is acceptable).