### PR TITLE
Use the documented API method to refresh auth token

### DIFF
--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -15,7 +15,7 @@ from .version import VERSION
 
 TUYA_ERROR_CODE_TOKEN_INVALID = 1010
 
-TO_C_REFRESH_TOKEN_API_PRE = "/v1.0/iot-03/users/token/"
+TO_C_REFRESH_TOKEN_API_PRE = "/v1.0/token/"
 
 TO_C_CUSTOM_TOKEN_API = "/v1.0/iot-03/users/login"
 TO_C_SMART_HOME_TOKEN_API = "/v1.0/iot-01/associated-users/actions/authorized-login"
@@ -154,7 +154,7 @@ class TuyaOpenAPI:
             return
 
         self.token_info.access_token = ""
-        response = self.post(
+        response = self.get(
             TO_C_REFRESH_TOKEN_API_PRE + self.token_info.refresh_token
         )
 


### PR DESCRIPTION
When running, if the token expires the client attempts to refresh it using the refresh_token.  When attempting to refresh the token (`__refresh_access_token_if_need()`), the response comes back:
`{'code': 1011, 'msg': 'token invalid', 'success': False, 't': 1640011165661}`

I could find no mention of the `/v1.0/iot-03/users/token/` endpoint in the API docs.  [This page](https://developer.tuya.com/en/docs/cloud/80bb968f1d?id=Ka7kjv3j8jgvr) describes a different endpoint.  Switching to that API seems to fix the issue.


Fixes #50

Also
home-assistant/core#62408
home-assistant/core#61903
home-assistant/core#61854
home-assistant/core#62318
home-assistant/core#61820