### PR TITLE
Add exponential backoff to MQTT client to prevent loop breaking on API failure

### DIFF
--- a/tuya_iot/openmq.py
+++ b/tuya_iot/openmq.py
@@ -12,6 +12,7 @@ from typing import Optional
 
 from Crypto.Cipher import AES
 from paho.mqtt import client as mqtt
+from requests.exceptions import RequestException
 
 from .openapi import TO_C_SMART_HOME_REFRESH_TOKEN_API, TuyaOpenAPI
 from .openlogging import logger
@@ -162,7 +163,8 @@ class TuyaOpenMQ(threading.Thread):
 
                 # reconnect every 2 hours required.
                 time.sleep(self.mq_config.expire_time - 60)
-            except:
+            except RequestException as e:
+                logger.exception(e)
                 logger.error(f"failed to refresh mqtt server, retrying in {backoff_seconds} seconds.")
 
                 time.sleep(backoff_seconds)


### PR DESCRIPTION
This fixes #56 where API errors are causing the MQTT reconnect to fail and the loop to stop - after which the MQTT client will stop receiving updates from the server.

I have implemented exponential backoff (with a cap at 60 seconds) - but I am happy to take feedback if this should be lower/higher as needed.