### PR TITLE
Fix TypeError: unsupported operand type(s) for +: 'int' and 'str'

### DIFF
--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -39,7 +39,7 @@ class TuyaTokenInfo:
 
         self.expire_time = (
             token_response.get("t", 0)
-            + result.get("expire", result.get("expire_time", 0)) * 1000
+            + int(result.get("expire", result.get("expire_time", 0))) * 1000
         )
         self.access_token = result.get("access_token", "")
         self.refresh_token = result.get("refresh_token", "")


### PR DESCRIPTION
Resolves this issue:
https://github.com/tuya/tuya-home-assistant/issues/851