### PR TITLE
Fix issue while adding new integration

### DIFF
--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -38,8 +38,8 @@ class TuyaTokenInfo:
         result = token_response.get("result", {})
 
         self.expire_time = (
-            token_response.get("t", 0)
-            + result.get("expire", result.get("expire_time", 0)) * 1000
+            int(token_response.get("t", 0))
+            + int(result.get("expire", result.get("expire_time", 0))) * 1000
         )
         self.access_token = result.get("access_token", "")
         self.refresh_token = result.get("refresh_token", "")


### PR DESCRIPTION
Fixes the below issue.

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 365, in async_setup
    result = await component.async_setup_entry(hass, self)
  File "/usr/src/homeassistant/homeassistant/components/tuya/__init__.py", line 79, in async_setup_entry
    response = await hass.async_add_executor_job(
  File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/local/lib/python3.10/site-packages/tuya_iot/openapi.py", line 222, in connect
    self.token_info = TuyaTokenInfo(response)
  File "/usr/local/lib/python3.10/site-packages/tuya_iot/openapi.py", line 41, in __init__
    token_response.get("t", 0)
TypeError: unsupported operand type(s) for +: 'int' and 'str'