### PR TITLE
 force reconnect to Tuya API if _get_mqtt_config() call fails

### DIFF
--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -227,6 +227,12 @@ class TuyaOpenAPI:
         """Is connect to tuya cloud."""
         return self.token_info is not None and len(self.token_info.access_token) > 0
 
+    def force_reconnect(self) -> bool:
+        self.connect(
+            self.__username, self.__password, self.__country_code, self.__schema
+        )
+        return self.is_connect()
+
     def __request(
         self,
         method: str,


### PR DESCRIPTION
This solves my issue with sudden stop device status update after several (usually 2) hours after last HA instance restart. There are several bug reports describing similar problem, such as #50 