### PR TITLE
Fix refreshing of the credentials in case the refresh token is expired

### DIFF
--- a/tuya_iot/openapi.py
+++ b/tuya_iot/openapi.py
@@ -281,7 +281,7 @@ class TuyaOpenAPI:
 
         if result.get("code", -1) == TUYA_ERROR_CODE_TOKEN_INVALID:
             self.token_info = None
-            self.connect(
+            return self.connect(
                 self.__username, self.__password, self.__country_code, self.__schema
             )
 


### PR DESCRIPTION
If the call to refresh the access token fails because the token is expired then the result of the new connect (which is a new refresh token and a new access token) should be stored in the TuyaTokenInfo that is created in the __refresh_access_token_if_need (line 168).

Without this code, the returned payload is the error one (code 1010) and is thus stored in the TuyaTokenInfo instead of the newly retrieved credentials.